### PR TITLE
Fix ammo loading on all turrets after w237/238 (ammo-table migration + slot-filter fix)

### DIFF
--- a/Turret_Variants/Turret_Variants.EXMOD
+++ b/Turret_Variants/Turret_Variants.EXMOD
@@ -37,7 +37,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_GENERIC.SFX_TURRET_FIRE_GENERIC",
           "ValidAmmoTypes": {
-            "RowName": "AllBolts"
+            "RowName": "TV_Bolts"
           }
         },
         {
@@ -65,7 +65,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_GENERIC.SFX_TURRET_FIRE_GENERIC",
           "ValidAmmoTypes": {
-            "RowName": "AllArrows"
+            "RowName": "TV_Arrows"
           }
         },
         {
@@ -93,7 +93,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_RIFLE.SFX_TURRET_FIRE_RIFLE",
           "ValidAmmoTypes": {
-            "RowName": "AllSnipers"
+            "RowName": "TV_Sniper"
           }
         },
         {
@@ -121,7 +121,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_RIFLE.SFX_TURRET_FIRE_RIFLE",
           "ValidAmmoTypes": {
-            "RowName": "AllAssaultRifle"
+            "RowName": "TV_AssaultRifle"
           }
         },
         {
@@ -149,7 +149,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_GENERIC.SFX_TURRET_FIRE_GENERIC",
           "ValidAmmoTypes": {
-            "RowName": "AllSubmachineGuns"
+            "RowName": "TV_Pistol"
           }
         },
         {
@@ -177,7 +177,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_GENERIC.SFX_TURRET_FIRE_GENERIC",
           "ValidAmmoTypes": {
-            "RowName": "AllJavelins"
+            "RowName": "TV_Javelin"
           }
         },
         {
@@ -233,7 +233,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_GENERIC.SFX_TURRET_FIRE_GENERIC",
           "ValidAmmoTypes": {
-            "RowName": "Rock_Golem_Gun"
+            "RowName": "TV_Rock"
           }
         },
         {
@@ -261,7 +261,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_RIFLE.SFX_TURRET_FIRE_RIFLE",
           "ValidAmmoTypes": {
-            "RowName": "AllRifle"
+            "RowName": "TV_Rifle"
           }
         },
         {
@@ -289,7 +289,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_RIFLE.SFX_TURRET_FIRE_RIFLE",
           "ValidAmmoTypes": {
-            "RowName": "AllRifle"
+            "RowName": "TV_Rifle"
           }
         },
         {
@@ -317,7 +317,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_GENERIC.SFX_TURRET_FIRE_GENERIC",
           "ValidAmmoTypes": {
-            "RowName": "AllPistol"
+            "RowName": "TV_Pistol"
           }
         },
         {
@@ -345,7 +345,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_SHOTGUN.SFX_TURRET_FIRE_SHOTGUN",
           "ValidAmmoTypes": {
-            "RowName": "AllShotgun"
+            "RowName": "TV_Shotgun"
           }
         },
         {
@@ -373,7 +373,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_GENERIC.SFX_TURRET_FIRE_GENERIC",
           "ValidAmmoTypes": {
-            "RowName": "AllBolts"
+            "RowName": "TV_Bolts"
           }
         },
         {
@@ -401,7 +401,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_RIFLE.SFX_TURRET_FIRE_RIFLE",
           "ValidAmmoTypes": {
-            "RowName": "AllAssaultRifle"
+            "RowName": "TV_AssaultRifle"
           }
         },
         {
@@ -429,7 +429,7 @@
           "FireParticle": "/Game/ASS/VFX/WEP/NS_PistolHandgunMuzzle.NS_PistolHandgunMuzzle",
           "FireSound": "/Game/FMOD/Events/SFX/Weapons/Guns/Turrets/SFX_TURRET_FIRE_RIFLE.SFX_TURRET_FIRE_RIFLE",
           "ValidAmmoTypes": {
-            "RowName": "AllSnipers"
+            "RowName": "TV_Sniper"
           }
         }
       ]
@@ -777,7 +777,7 @@
             "RowName": "Turret_Repairable"
           },
           "Inventory": {
-            "RowName": "Inventory_Turret_Pistol"
+            "RowName": "Inventory_Turret_TV_AnyAmmo"
           },
           "Decayable": {
             "RowName": "Decay_10_Minutes"
@@ -870,7 +870,7 @@
             "RowName": "Turret_Repairable"
           },
           "Inventory": {
-            "RowName": "Inventory_Turret_Pistol"
+            "RowName": "Inventory_Turret_TV_AnyAmmo"
           },
           "Decayable": {
             "RowName": "Decay_10_Minutes"
@@ -1242,7 +1242,7 @@
             "RowName": "Turret_Repairable"
           },
           "Inventory": {
-            "RowName": "Inventory_Turret_Rifle"
+            "RowName": "Inventory_Turret_TV_Thrown"
           },
           "Decayable": {
             "RowName": "Decay_10_Minutes"
@@ -1428,7 +1428,7 @@
             "RowName": "Turret_Repairable"
           },
           "Inventory": {
-            "RowName": "Inventory_Turret_Pistol"
+            "RowName": "Inventory_Turret_TV_Rock"
           },
           "Decayable": {
             "RowName": "Decay_10_Minutes"
@@ -1893,7 +1893,7 @@
             "RowName": "Turret_Repairable"
           },
           "Inventory": {
-            "RowName": "Inventory_Turret_Pistol"
+            "RowName": "Inventory_Turret_TV_AnyAmmo"
           },
           "Decayable": {
             "RowName": "Decay_10_Minutes"
@@ -3575,6 +3575,616 @@
               "Amount": 1
             }
           ]
+        }
+      ]
+    },
+    {
+      "CurrentFile": "Tools-D_ValidAmmoTypes.json",
+      "File_Items": [
+        {
+          "Name": "TV_Pistol",
+          "AmmoTypes": [
+            {
+              "RowName": "Ammo_Pistol_Round",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Pistol_Round_Armor_Piercing",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Pistol_Round_Cold_Steel",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Pistol_Round_Explosive",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Pistol_Round_Incendiary",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Pistol_Round_Iron_Wood",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Pistol_Round_Lithium",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Pistol_Round_Obsidian",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Pistol_Round_Uranium",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Pistol_Round_Workshop",
+              "DataTableName": "D_ItemsStatic"
+            }
+          ]
+        },
+        {
+          "Name": "TV_AssaultRifle",
+          "AmmoTypes": [
+            {
+              "RowName": "Ammo_AssaultRifle_Round",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_AssaultRifle_Round_Armor_Piercing",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_AssaultRifle_Round_Cold_Steel",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_AssaultRifle_Round_Explosive",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_AssaultRifle_Round_Incendiary",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_AssaultRifle_Round_Iron_Wood",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_AssaultRifle_Round_Lithium",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_AssaultRifle_Round_Obsidian",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_AssaultRifle_Round_Uranium",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_AssaultRifle_Round_Workshop",
+              "DataTableName": "D_ItemsStatic"
+            }
+          ]
+        },
+        {
+          "Name": "TV_Rifle",
+          "AmmoTypes": [
+            {
+              "RowName": "Ammo_Rifle_Round",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Rifle_Round_Armor_Piercing",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Rifle_Round_Cold_Steel",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Rifle_Round_Explosive",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Rifle_Round_Incendiary",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Rifle_Round_Iron_Wood",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Rifle_Round_Lithium",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Rifle_Round_Obsidian",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Rifle_Round_Uranium",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Rifle_Round_Workshop",
+              "DataTableName": "D_ItemsStatic"
+            }
+          ]
+        },
+        {
+          "Name": "TV_Sniper",
+          "AmmoTypes": [
+            {
+              "RowName": "Ammo_Sniper_Round",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Sniper_Round_Explosive",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Sniper_Round_Illumination",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Sniper_Round_Incendiary",
+              "DataTableName": "D_ItemsStatic"
+            }
+          ]
+        },
+        {
+          "Name": "TV_Shotgun",
+          "AmmoTypes": [
+            {
+              "RowName": "Ammo_Shell_Buckshot",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Shell_ColdSteel",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Shell_Explosive",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Shell_Ironwood",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Shell_Lithium",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Shell_Obsidian",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Shell_Slug",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Shell_Uranium",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Ammo_Shell_Workshop",
+              "DataTableName": "D_ItemsStatic"
+            }
+          ]
+        },
+        {
+          "Name": "TV_Bolts",
+          "AmmoTypes": [
+            {
+              "RowName": "Copper_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Bolt_Larkwell_Standard",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Bolt_Larkwell_Whistling",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Metal_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Platinum_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Steel_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Titanium_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Tranquilizer_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Obsidian_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Cold_Steel_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Iron_Wood_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Bolt_Larkwell_Electroshock",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Bolt_Larkwell_Explosive",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Bolt_Larkwell_Piercing",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Scyther_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Lithium_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Uranium_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Metal_Alloy_Bolt",
+              "DataTableName": "D_ItemsStatic"
+            }
+          ]
+        },
+        {
+          "Name": "TV_Arrows",
+          "AmmoTypes": [
+            {
+              "RowName": "Aluminium_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Black_Wolf_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Bone_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Carbon_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Caveworm_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Composite_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Fire_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Flare_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Flint_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Inaris_Alpha",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Inaris_Bravo",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Inaris_Charlie",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Inaris_Delta",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Larkwell_Bait",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Larkwell_Ballistic",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Larkwell_Bleed",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Larkwell_Standard",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Larkwell_Tazer",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Larkwell_Whistling",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Printed_Alpha",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Printed_Beta",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Printed_Charlie",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Meta_Arrow_Shengong",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Poison_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Sandworm_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Steel_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Stone_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Titanium_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Obsidian_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Cold_Steel_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Iron_Wood_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Scyther_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Drill_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Lithium_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Uranium_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Metal_Alloy_Arrow",
+              "DataTableName": "D_ItemsStatic"
+            }
+          ]
+        },
+        {
+          "Name": "TV_Javelin",
+          "AmmoTypes": [
+            {
+              "RowName": "Bone_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Carbon_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Caveworm_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Cold_Steel_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Composite_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "IceMammoth_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Iron_Wood_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Lithium_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Metal_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Obsidian_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Platinum_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Sandworm_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Steel_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Titanium_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            },
+            {
+              "RowName": "Wood_Throwing_Spear",
+              "DataTableName": "D_ItemsStatic"
+            }
+          ]
+        },
+        {
+          "Name": "TV_Rock",
+          "AmmoTypes": [
+            {
+              "RowName": "Stone",
+              "DataTableName": "D_ItemsStatic"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "CurrentFile": "Tags-D_TagQueries.json",
+      "File_Items": [
+        {
+          "Name": "TV_Thrown_Ammo",
+          "Query": {
+            "TagDictionary": [
+              {
+                "TagName": "Item.Weapon.Spear.Thrown"
+              }
+            ],
+            "QueryTokenStream": [
+              0,
+              1,
+              1,
+              1,
+              0
+            ],
+            "AutoDescription": " ANY( Item.Weapon.Spear.Thrown )"
+          }
+        },
+        {
+          "Name": "TV_Rock_Ammo",
+          "Query": {
+            "TagDictionary": [
+              {
+                "TagName": "Item.Resource.Stone"
+              }
+            ],
+            "QueryTokenStream": [
+              0,
+              1,
+              1,
+              1,
+              0
+            ],
+            "AutoDescription": " ANY( Item.Resource.Stone )"
+          }
+        }
+      ]
+    },
+    {
+      "CurrentFile": "Traits-D_Inventory.json",
+      "File_Items": [
+        {
+          "Name": "Inventory_Turret_TV_AnyAmmo",
+          "Inventories": [
+            {
+              "RowName": "Inventory_Turret_TV_AnyAmmo",
+              "DataTableName": "D_InventoryInfo"
+            }
+          ]
+        },
+        {
+          "Name": "Inventory_Turret_TV_Thrown",
+          "Inventories": [
+            {
+              "RowName": "Inventory_Turret_TV_Thrown",
+              "DataTableName": "D_InventoryInfo"
+            }
+          ]
+        },
+        {
+          "Name": "Inventory_Turret_TV_Rock",
+          "Inventories": [
+            {
+              "RowName": "Inventory_Turret_TV_Rock",
+              "DataTableName": "D_InventoryInfo"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "CurrentFile": "Inventory-D_InventoryInfo.json",
+      "File_Items": [
+        {
+          "Name": "Inventory_Turret_TV_AnyAmmo",
+          "InventoryID": {
+            "Value": "General"
+          },
+          "SlotTemplate": {
+            "RowName": "Any_Ammo"
+          },
+          "StartingSlots": 4
+        },
+        {
+          "Name": "Inventory_Turret_TV_Thrown",
+          "InventoryID": {
+            "Value": "General"
+          },
+          "SlotTemplate": {
+            "RowName": "TV_Thrown_Ammo"
+          },
+          "StartingSlots": 4
+        },
+        {
+          "Name": "Inventory_Turret_TV_Rock",
+          "InventoryID": {
+            "Value": "General"
+          },
+          "SlotTemplate": {
+            "RowName": "TV_Rock_Ammo"
+          },
+          "StartingSlots": 4
         }
       ]
     }


### PR DESCRIPTION
## Summary
Restores ammo loading on all 15 turret variants, which broke with the Week 237/238
update. Builds on v3.3 (mesh fix) — this PR is purely the ammo side. All changes are
additive; no vanilla rows are overwritten.

## What broke
Two separate things, both from the update streamlining game tables:

1. **Dead ammo categories.** The per-type vanilla `ValidAmmoTypes` rows the turrets
   referenced (`AllPistol`, `AllArrows`, `AllBolts`, `AllJavelins`, `Rock_Golem_Gun`,
   etc.) were removed/renamed, so every turret's ammo reference dangled.
2. **Slot tag filter.** All turrets reused the vanilla `Inventory_Turret_Pistol`,
   whose slot only admits `Item.Ammo.*`-tagged items. Even after fixing the ammo rows,
   arrows/bolts loaded but throwing spears (`Item.Weapon.Spear.Thrown`) and stone
   (`Item.Resource.Stone`) were rejected at the slot before `ValidAmmoTypes` was checked.
   Javelins were also renamed `*_Throwing_Spear` (the word "Javelin" was dropped).

## Changes (all additive)
- **`D_ValidAmmoTypes`** — 9 self-contained `TV_` rows (Pistol, AssaultRifle, Rifle,
  Sniper, Shotgun, Bolts, Arrows, Javelin, Rock) populated from current item names.
- **`D_TagQueries`** — 2 new slot queries: `TV_Thrown_Ammo` (`ANY(Item.Weapon.Spear.Thrown)`)
  and `TV_Rock_Ammo` (`ANY(Item.Resource.Stone)`).
- **`D_Inventory` / `D_InventoryInfo`** — 3 custom turret inventories at 4 slots each:
  standard ammo, thrown spears, and stone.
- **`D_Turret`** — repointed 14 turrets to the new `TV_` ammo rows (Flamethrower left on
  vanilla `BioFuel`, which survived the update).
- **`D_ItemsStatic`** — repointed 5 turret items (Bow, Crossbow, RapidCrossbow, Javelin,
  Rock) to the matching new inventory.

Ammo lists were verified against the current extracted `D_ItemsStatic` and cross-checked
with Jimk72's `All_Ammo_Turret` and Ferani's `Compatible_Ammo` for the current naming
(e.g. the 5.56 `Ammo_AssaultRifle_Round` vs 7.62 `Ammo_Rifle_Round` split, and the
`*_Throwing_Spear` rename). Self-contained `TV_` rows mean future vanilla table changes
won't re-break this.

## Testing
- ✅ All 15 turrets load their correct ammo type in-game.
- 🔲 Firing/projectile pass still in progress. One known caveat: the Quarrite Gun applies
  a weapon-side projectile-damage bonus the turret won't have, so the Rock Thrower's
  stone may hit softer — likely a damage-tuning tweak, not a mechanic issue.

## Notes
The Rock Thrower fires real `Stone` (which carries its own `Ballistic` + `AmmoType`),
not a substitute. Open to feedback on naming/conventions for the `TV_` rows if you'd
prefer something else.